### PR TITLE
Allow for customization of the schedule start time

### DIFF
--- a/cron.go
+++ b/cron.go
@@ -11,19 +11,20 @@ import (
 // specified by the schedule. It may be started, stopped, and the entries may
 // be inspected while running.
 type Cron struct {
-	entries   []*Entry
-	chain     Chain
-	stop      chan struct{}
-	add       chan *Entry
-	remove    chan EntryID
-	snapshot  chan chan []Entry
-	running   bool
-	logger    Logger
-	runningMu sync.Mutex
-	location  *time.Location
-	parser    ScheduleParser
-	nextID    EntryID
-	jobWaiter sync.WaitGroup
+	entries      []*Entry
+	chain        Chain
+	stop         chan struct{}
+	add          chan *Entry
+	remove       chan EntryID
+	snapshot     chan chan []Entry
+	running      bool
+	logger       Logger
+	runningMu    sync.Mutex
+	location     *time.Location
+	scheduleFrom time.Time
+	parser       ScheduleParser
+	nextID       EntryID
+	jobWaiter    sync.WaitGroup
 }
 
 // ScheduleParser is an interface for schedule spec parsers that return a Schedule
@@ -241,6 +242,9 @@ func (c *Cron) run() {
 
 	// Figure out the next activation times for each entry.
 	now := c.now()
+	if !c.scheduleFrom.IsZero() {
+		now = c.scheduleFrom
+	}
 	for _, entry := range c.entries {
 		entry.Next = entry.Schedule.Next(now)
 		c.logger.Info("schedule", "now", now, "entry", entry.ID, "next", entry.Next)

--- a/option.go
+++ b/option.go
@@ -43,3 +43,10 @@ func WithLogger(logger Logger) Option {
 		c.logger = logger
 	}
 }
+
+// WithInitialTime sets the Time to begin scheduling from.
+func WithInitialTime(t time.Time) Option {
+	return func(c *Cron) {
+		c.scheduleFrom = t
+	}
+}


### PR DESCRIPTION
If Cron is not active when a schedule occurs, it's possible we'll miss
a task that we need to run. We've seen this happen when schedules
coincide with a deploy.

This commit adds a configuration option which will allow us to set the
initial start time. We can "catch up" missed tasks by passing the
shutdown time on creation.